### PR TITLE
Update start date to Feb 2022

### DIFF
--- a/RDO-051.tex
+++ b/RDO-051.tex
@@ -49,7 +49,7 @@ Users Committee members may also participate in User Acceptance Testing for the 
 The Users Committee will regularly report to the Rubin Lead Community Scientist and to the Rubin Observatory Director with recommendations for science-driven improvements to the LSST data products and the RSP tools and services.
 Their goal is to maximize the scientific productivity of the user community, while prioritizing equitable access and inclusive practices throughout the diverse user community. 
 
-The Users Committee will be a standing committee in place by fall 2021, and will continue through the life of Rubin Observatory operations.
+The Users Committee will be a standing committee in place by February 2022, and will continue through the life of Rubin Observatory operations.
 Before the start of the 10-year survey, the focus of the committee will be on the Data Previews (which will include simulation data, precursor survey data, and commissioning data), and community involvement thereof.
 Once the 10-year LSST is underway, the focus of the committee will shift to use of the RSP, the regular data releases, the alert stream, and the prompt data products.  
 


### PR DESCRIPTION
Current document says "The Users Committee will be a standing committee in place by fall 2021".  Should that be updated to February 2022, given the stated timeline in the email invitation?